### PR TITLE
fix: Security 초기 범주 설정

### DIFF
--- a/src/main/java/backend/airo/security/config/SecurityConfig.java
+++ b/src/main/java/backend/airo/security/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/webjars/**"
                         ).permitAll()
-                        .anyRequest().authenticated()
+//                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 );
 
         return http.build();


### PR DESCRIPTION
1. 초기 Securirty 범주 설정 ( 모두 허용 / 임시

```
    @Bean
    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
        http
                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                .csrf(CsrfConfigurer::disable) // CSRF 비활성화
                .httpBasic(HttpBasicConfigurer::disable) // HTTP Basic 인증 비활성화
//                //JWT 사용시 session 비활성화
//                .sessionManagement(sessionManagement -> sessionManagement
//                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                .authorizeHttpRequests(authRequests -> authRequests
                        .requestMatchers(
                                "/swagger-ui/**",
                                "/v3/api-docs/**",
                                "/swagger-resources/**",
                                "/webjars/**"
                        ).permitAll()
//                        .anyRequest().authenticated()
                        .anyRequest().permitAll()
                );

        return http.build();
    }
```
